### PR TITLE
added shr_flds_mod.F90 file - that should have been added in previous…

### DIFF
--- a/src/share/util/shr_flds_mod.F90
+++ b/src/share/util/shr_flds_mod.F90
@@ -1,0 +1,15 @@
+module shr_flds_mod
+
+   use shr_kind_mod      , only : CX => shr_kind_CX, CXX => shr_kind_CXX
+
+   implicit none
+   public
+
+   !----------------------------------------------------------------------------
+   ! for the domain
+   !----------------------------------------------------------------------------
+
+   character(CXX) :: shr_flds_dom_coord
+   character(CXX) :: shr_flds_dom_other
+
+end module shr_flds_mod


### PR DESCRIPTION
Add shr_flds_mod.F90 to share/utils/

This adds the file shr_flds_mod.F90 to share utils - which did not get added correctly in the previous PR.

This will introduce a new cime tag nuopcB_180109 that should be used for the previous PR.

Test suite: None
Test baseline: None
Test namelist changes: None
Test status: [bit for bit, roundoff, climate changing]

Fixes:

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
