### PR TITLE
Initial changes for MOM6 support in CIME

### DIFF
--- a/config/cesm/config_files.xml
+++ b/config/cesm/config_files.xml
@@ -115,7 +115,8 @@
     <type>char</type>
     <default_value>unset</default_value>
     <values>
-      <value component="pop"      >$SRCROOT/components/pop/</value>
+      <value component="pop"       >$SRCROOT/components/pop/</value>
+      <value component="mom"       >$SRCROOT/components/mom</value>
       <value component="docn"      >$CIMEROOT/src/components/data_comps/docn</value>
       <value component="socn"      >$CIMEROOT/src/components/stub_comps/socn</value>
       <value component="xocn"      >$CIMEROOT/src/components/xcpl_comps/xocn</value>
@@ -227,6 +228,7 @@
       <value component="clm"      >$COMP_ROOT_DIR_LND/cime_config/config_compsets.xml</value>
       <value component="cice"     >$COMP_ROOT_DIR_ICE/cime_config/config_compsets.xml</value>
       <value component="pop"      >$COMP_ROOT_DIR_OCN/cime_config/config_compsets.xml</value>
+      <value component="mom"      >$COMP_ROOT_DIR_OCN/cime_config/config_compsets.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>
@@ -246,6 +248,7 @@
       <value component="clm"      >$COMP_ROOT_DIR_LND/cime_config/config_pes.xml</value>
       <value component="cice"     >$COMP_ROOT_DIR_ICE/cime_config/config_pes.xml</value>
       <value component="pop"      >$COMP_ROOT_DIR_OCN/cime_config/config_pes.xml</value>
+      <value component="mom"      >$COMP_ROOT_DIR_OCN/cime_config/config_pes.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>
@@ -271,6 +274,7 @@
       <value component="clm"      >$COMP_ROOT_DIR_LND/cime_config/config_archive.xml</value>
       <value component="cice"     >$COMP_ROOT_DIR_ICE/cime_config/config_archive.xml</value>
       <value component="pop"      >$COMP_ROOT_DIR_OCN/cime_config/config_archive.xml</value>
+      <value component="mom"      >$COMP_ROOT_DIR_OCN/cime_config/config_archive.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>
@@ -285,6 +289,7 @@
       <value component="clm">$COMP_ROOT_DIR_LND/cime_config/SystemTests</value>
       <value component="cam">$COMP_ROOT_DIR_ATM/cime_config/SystemTests</value>
       <value component="pop">$COMP_ROOT_DIR_OCN/cime_config/SystemTests</value>
+      <value component="mom">$COMP_ROOT_DIR_OCN/cime_config/SystemTests</value>
       <value component="cice">$COMP_ROOT_DIR_ICE/cime_config/SystemTests</value>
       <value component="cism">$COMP_ROOT_DIR_GLC/cime_config/SystemTests</value>
       <value component="rtm">$COMP_ROOT_DIR_ROF/cime_config/SystemTests</value>
@@ -307,6 +312,7 @@
       <value component="clm"      >$COMP_ROOT_DIR_LND/cime_config/testdefs/testlist_clm.xml</value>
       <value component="cice"     >$COMP_ROOT_DIR_ICE/cime_config/testdefs/testlist_cice.xml</value>
       <value component="pop"      >$COMP_ROOT_DIR_OCN/cime_config/testdefs/testlist_pop.xml</value>
+      <value component="mom"      >$COMP_ROOT_DIR_OCN/cime_config/testdefs/testlist_mom.xml</value>
       <value component="rtm"      >$COMP_ROOT_DIR_ROF/cime_config/testdefs/testlist_rtm.xml</value>
       <value component="mosart"   >$COMP_ROOT_DIR_ROF/cime_config/testdefs/testlist_mosart.xml</value>
     </values>
@@ -330,6 +336,7 @@
       <value component="rtm"      >$COMP_ROOT_DIR_ROF/cime_config/testdefs/testmods_dirs</value>
       <value component="mosart"   >$COMP_ROOT_DIR_ROF/cime_config/testdefs/testmods_dirs</value>
       <value component="pop"      >$COMP_ROOT_DIR_OCN/cime_config/testdefs/testmods_dirs</value>
+      <value component="mom"      >$COMP_ROOT_DIR_OCN/cime_config/testdefs/testmods_dirs</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>
@@ -350,6 +357,7 @@
       <value component="rtm"      >$COMP_ROOT_DIR_ROF/cime_config/usermods_dirs</value>
       <value component="mosart"   >$COMP_ROOT_DIR_ROF/cime_config/usermods_dirs</value>
       <value component="pop"      >$COMP_ROOT_DIR_OCN/cime_config/usermods_dirs</value>
+      <value component="mom"      >$COMP_ROOT_DIR_OCN/cime_config/usermods_dirs</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>
@@ -381,6 +389,7 @@
       <value component="clm"      >$COMP_ROOT_DIR_LND/bld/namelist_files/namelist_definition_clm4_5.xml</value>
       <value component="clm"      >$COMP_ROOT_DIR_LND/bld/namelist_files/namelist_definition_clm4_0.xml</value>
       <value component="pop"      >$COMP_ROOT_DIR_OCN/bld/namelist_files/namelist_definition_pop.xml</value>
+      <value component="mom"      >$COMP_ROOT_DIR_OCN/bld/namelist_files/namelist_definition_mom.xml</value>
       -->
     </values>
     <group>case_last</group>

--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -1093,7 +1093,7 @@
     </domain>
 
     <domain name="T62">
-      <nx>192</nx>  <ny>96</ny>
+      <nx>192</nx>  <ny>94</ny>
       <file grid="atm|lnd" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_gx1v7.151008.nc</file>
       <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_gx1v6.090320.nc</file>
       <file grid="atm|lnd" mask="gx3v7">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_gx3v7.090911.nc</file>

--- a/config/cesm/machines/Makefile
+++ b/config/cesm/machines/Makefile
@@ -68,6 +68,10 @@ else
    USE_CXX = false
 endif
 
+ifeq ($(strip $(USE_FMS)), TRUE)
+  SLIBS += -lfms
+endif 
+
 ifndef MOD_SUFFIX
    MOD_SUFFIX := mod
 endif

--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -1117,4 +1117,11 @@ using a fortran linker.
   <NETCDF_PATH>$ENV{NETCDF_DIR}</NETCDF_PATH>
 </compiler>
 
+<compiler COMPILER="intel" MACH="theia">
+  <MPICC> mpiicc  </MPICC>
+  <MPICXX> mpiicpc </MPICXX>
+  <MPIFC> mpiifort </MPIFC>
+  <NETCDF_PATH>/apps/netcdf/4.3.0-intel</NETCDF_PATH>
+</compiler>
+
 </config_compilers>

--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -685,6 +685,9 @@ using a fortran linker.
     <append MPILIB="mvapich2"> -mkl=cluster </append>
   </SLIBS>
   <PFUNIT_PATH MPILIB="mpi-serial" compile_threaded="false">/fs/cgd/csm/tools/pFUnit/pFUnit3.2.8_hobart_Intel15.0.2_noMPI_noOpenMP</PFUNIT_PATH>
+  <FFLAGS>
+    <append MODEL="mom"> -r8 </append>
+  </FFLAGS>
 </compiler>
 
 <compiler MACH="hobart" COMPILER="nag">
@@ -1009,6 +1012,9 @@ using a fortran linker.
   <PFUNIT_PATH MPILIB="mpt" compile_threaded="true">$ENV{CESMDATAROOT}/tools/pFUnit/pFUnit3.2.8_cheyenne_Intel17.0.1_MPI_openMP</PFUNIT_PATH>
   <!-- Bug in the intel/17.0.1 compiler requires this, remove this line when compiler is updated -->
   <HAS_F2008_CONTIGUOUS>FALSE</HAS_F2008_CONTIGUOUS>
+  <FFLAGS>
+    <append MODEL="mom"> -r8 </append>
+  </FFLAGS>
 </compiler>
 
 <compiler MACH="laramie">
@@ -1108,13 +1114,6 @@ using a fortran linker.
     <append DEBUG="TRUE"> -ftrapuv </append>
   </CFLAGS> 
   <NETCDF_PATH>$ENV{NETCDF_DIR}</NETCDF_PATH>
-</compiler>
-
-<compiler COMPILER="intel" MACH="theia">
-  <MPICC> mpiicc  </MPICC>
-  <MPICXX> mpiicpc </MPICXX>
-  <MPIFC> mpiifort </MPIFC>
-  <NETCDF_PATH>/apps/netcdf/4.3.0-intel</NETCDF_PATH>
 </compiler>
 
 </config_compilers>

--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -69,8 +69,9 @@ using a fortran linker.
      compilers -->
 <compiler>
   <CPPDEFS>
-    <append> -D<env>OS</env> </append>
+    <append> -D<env>OS</env> -DCESMCOUPLED </append>
     <append MODEL="pop"> -D_USE_FLOW_CONTROL </append>
+    <append MODEL="mom"> -DMOM6_CAP </append>
   </CPPDEFS>
   <SUPPORTS_CXX>FALSE</SUPPORTS_CXX>
 </compiler>

--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -1122,6 +1122,9 @@ using a fortran linker.
   <MPICXX> mpiicpc </MPICXX>
   <MPIFC> mpiifort </MPIFC>
   <NETCDF_PATH>/apps/netcdf/4.3.0-intel</NETCDF_PATH>
+  <FFLAGS>
+    <append MODEL="mom"> -r8 </append>
+  </FFLAGS>
 </compiler>
 
 </config_compilers>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -2007,12 +2007,12 @@
       <cmd_path lang="python">/apps/lmod/lmod/libexec/lmod python</cmd_path>
       <modules compiler="intel">
 	<command name="purge"/>
-	<command name="load">intel/15.1.133</command>
+	<command name="load">intel</command>
 	<command name="load">impi/5.1.1.109</command>
 	<command name="load">netcdf/4.3.0</command>
 	<command name="load">pnetcdf</command>
 	<command name="use">/scratch4/NCEPDEV/nems/noscrub/emc.nemspara/soft/modulefiles</command>
-	<command name="load">esmf/7.1.0bs46</command>
+	<command name="load">esmf/7.1.0r</command>
       </modules>
     </module_system>
   </machine>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -946,6 +946,9 @@
       <!-- <env name="ESMFMKFILE">/home/fischer/ESMF_code/ESMF_7_1_0_beta/lib/libg/Linux.intel.64.mvapich2.default/esmf.mk</env> -->
       <env name="ESMFMKFILE">/home/fischer/ESMF_code/ESMF_7_1_0_beta_snapshot_42/lib/libg/Linux.intel.64.mvapich2.default/esmf.mk</env>
     </environment_variables>
+    <resource_limits>
+      <resource name="RLIMIT_STACK">-1</resource>
+    </resource_limits>
   </machine>
 
 

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -1975,10 +1975,10 @@
     <PROJECT>nems</PROJECT>
     <SAVE_TIMING_DIR> </SAVE_TIMING_DIR>
     <CIME_OUTPUT_ROOT>/scratch4/NCEPDEV/nems/noscrub/$USER/cimecases</CIME_OUTPUT_ROOT>
-    <DIN_LOC_ROOT>$ENV{CESMDATAROOT}/inputdata</DIN_LOC_ROOT>
-    <DIN_LOC_ROOT_CLMFORC>$ENV{CESMDATAROOT}/lmwg</DIN_LOC_ROOT_CLMFORC>
+    <DIN_LOC_ROOT>/scratch4/NCEPDEV/nems/noscrub/Anthony.Craig/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/scratch4/NCEPDEV/nems/noscrub/Anthony.Craig/lmwg</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
-    <BASELINE_ROOT>$ENV{CESMDATAROOT}/cesm_baselines</BASELINE_ROOT>
+    <BASELINE_ROOT>/scratch4/NCEPDEV/nems/noscrub/Anthony.Craig/cesm_baselines</BASELINE_ROOT>
     <!--<CCSM_CPRNC>$ENV{CESMDATAROOT}/tools/cime/tools/cprnc/cprnc.cheyenne</CCSM_CPRNC>-->
     <GMAKE>make</GMAKE>
     <GMAKE_J>8</GMAKE_J>

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -540,6 +540,7 @@ class Case(object):
         """
 
         component = self.get_primary_component()
+        logger.info("Primary component is %s"%component)
 
         if pesfile is None:
             self._pesfile = files.get_value("PES_SPEC_FILE", {"component":component})

--- a/src/drivers/mct/cime_config/buildexe
+++ b/src/drivers/mct/cime_config/buildexe
@@ -33,6 +33,10 @@ def _main_func():
         model     = case.get_value("MODEL")
         num_esp   = case.get_value("NUM_COMP_INST_ESP")
         os.environ["PIO_VERSION"] = str(case.get_value("PIO_VERSION"))
+        ocn_model = case.get_value("COMP_OCN")
+
+    if ocn_model == 'mom':
+        os.environ["USE_FMS"] = "TRUE"
 
     expect((num_esp is None) or (int(num_esp) == 1), "ESP component restricted to one instance")
         

--- a/src/drivers/mct/cime_config/namelist_definition_nuopc.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_nuopc.xml
@@ -18,7 +18,7 @@
     <category>nuopc</category>
     <group>DRIVER_attributes</group>
     <values>
-      <value>0</value>
+      <value>1</value>
     </values>
   </entry>
 

--- a/src/drivers/nuopc/cime_config/buildexe
+++ b/src/drivers/nuopc/cime_config/buildexe
@@ -33,6 +33,10 @@ def _main_func():
         model     = case.get_value("MODEL")
         num_esp   = case.get_value("NUM_COMP_INST_ESP")
         os.environ["PIO_VERSION"] = str(case.get_value("PIO_VERSION"))
+        ocn_model = case.get_value("COMP_OCN")
+
+    if ocn_model == 'mom':
+        os.environ["USE_FMS"] = "TRUE"
 
     expect((num_esp is None) or (int(num_esp) == 1), "ESP component restricted to one instance")
         

--- a/src/drivers/nuopc/cime_driver/esm.F90
+++ b/src/drivers/nuopc/cime_driver/esm.F90
@@ -71,8 +71,8 @@ module ESM
 #ifdef ESMFUSE_NOTYET_mosart
   use mosart_comp_nuopc, only: mosart_SS => SetServices
 #endif
-#ifdef ESMFUSE_NOTYET_mom6
-  use mom6_comp_nuopc, only:   mom6_SS => SetServices
+#ifdef ESMFUSE_mom
+  use mom_cap_mod, only:   mom_SS => SetServices
 #endif
 #ifdef ESMFUSE_NOTYET_ww3
   use  ww3_comp_nuopc, only:   ww3_SS => SetServices
@@ -572,9 +572,9 @@ module ESM
             line=__LINE__, file=u_FILE_u, rcToReturn=rc)
           return  ! bail out
 #endif
-        elseif (trim(model) == "mom6") then
-#ifdef ESMFUSE_NOTYET_mom6
-          call NUOPC_DriverAddComp(driver, "OCN", mom6_SS, petList=petList, comp=child, rc=rc)
+        elseif (trim(model) == "mom") then
+#ifdef ESMFUSE_mom
+          call NUOPC_DriverAddComp(driver, "OCN", mom_SS, petList=petList, comp=child, rc=rc)
           if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 #else
           call ESMF_LogSetError(ESMF_RC_NOT_VALID, &

--- a/src/drivers/nuopc/mediator/med_phases_mod.F90
+++ b/src/drivers/nuopc/mediator/med_phases_mod.F90
@@ -1251,6 +1251,43 @@ module med_phases_mod
     if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
     !---------------------------------------
+    !--- custom calculations
+    !---------------------------------------
+
+    ! TODO: document custom merges below
+    ! TODO: need to obtain flux_epbalfact
+
+    call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBImp(compatm,compocn), 'Faxa_rainc', dataPtr1, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBImp(compatm,compocn), 'Faxa_rainl', dataPtr2, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBExp(compocn), 'Foxx_rain' , dataPtr3, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    dataPtr3(:) = dataPtr1(:) + dataPtr2(:)
+#if (1 == 0)
+    dataPtr3(:) = dataPtr3(:) * flux_epbalfact
+#endif
+
+    call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBImp(compatm,compocn), 'Faxa_snowc', dataPtr1, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBImp(compatm,compocn), 'Faxa_snowl', dataPtr2, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBExp(compocn), 'Foxx_snow' , dataPtr3, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    dataPtr3(:) = dataPtr1(:) + dataPtr2(:)
+#if (1 == 0)
+    dataPtr3(:) = dataPtr3(:) * flux_epbalfact
+#endif
+
+    call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBExp(compocn), 'Foxx_rain' , dataPtr1, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBExp(compocn), 'Foxx_snow' , dataPtr2, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_nuopc_methods_FB_GetFldPtr(is_local%wrap%FBExp(compocn), 'Foxx_prec' , dataPtr3, rc=rc)
+    if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+    dataPtr3(:) = dataPtr1(:) + dataPtr2(:)
+
+    !---------------------------------------
     !--- zero accumulator
     !---------------------------------------
 
@@ -1569,6 +1606,9 @@ module med_phases_mod
        if (dbug_flag > 1) then
           call shr_nuopc_methods_FB_diagnose(is_local%wrap%FBImp(compatm,compocn), &
                string=trim(subname) //' FBImp('//trim(compname(compatm))//','//trim(compname(compocn))//') ', rc=rc)
+          if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+          call shr_nuopc_methods_FB_diagnose(is_local%wrap%FBImp(compocn,compocn), &
+               string=trim(subname) //' FBImp('//trim(compname(compocn))//','//trim(compname(compocn))//') ', rc=rc)
           if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
        end if
 

--- a/src/drivers/nuopc/shr/shr_nuopc_fldList_mod.F90
+++ b/src/drivers/nuopc/shr/shr_nuopc_fldList_mod.F90
@@ -228,6 +228,11 @@ contains
        fldlist%shortname(num) = trim(stdname)
     endif
 
+    write(infostr,'(i6)') fldlist%num
+    call ESMF_LogWrite(trim(subname)//":"//trim(tag)//":n="//trim(infostr)//":fld="//trim(stdname), &
+         ESMF_LOGMSG_INFO, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+
   end subroutine shr_nuopc_fldList_Add
 
 !================================================================================

--- a/src/drivers/nuopc/shr/shr_nuopc_flds_mod.F90
+++ b/src/drivers/nuopc/shr/shr_nuopc_flds_mod.F90
@@ -626,6 +626,7 @@ contains
     call fld_add(flds_a2x, flds_a2x_map, "Faxa_swndr", longname=longname, stdname=stdname, units=units)
     call fld_add(flds_x2i, flds_x2i_map, "Faxa_swndr")
     call fld_add(flds_x2l, flds_x2l_map, "Faxa_swndr")
+    call fld_add(flds_x2o, flds_x2o_map, "Foxx_swndr", longname=longname, stdname=stdname, units=units)
 
     ! direct visible incident solar radiation
     longname = 'Direct visible incident solar radiation'
@@ -633,7 +634,9 @@ contains
     units    = 'W m-2'
     call fld_add(flds_a2x, flds_a2x_map, "Faxa_swvdr", longname=longname, stdname=stdname, units=units)
     call fld_add(flds_x2i, flds_x2i_map, "Faxa_swvdr")
+    call fld_add(flds_x2o, flds_x2o_map, "Faxa_swvdr")
     call fld_add(flds_x2l, flds_x2l_map, "Faxa_swvdr")
+    call fld_add(flds_x2o, flds_x2o_map, "Foxx_swvdr", longname=longname, stdname=stdname, units=units)
 
     ! diffuse near-infrared incident solar radiation
     longname = 'Diffuse near-infrared incident solar radiation'
@@ -642,6 +645,7 @@ contains
     call fld_add(flds_a2x, flds_a2x_map, "Faxa_swndf", longname=longname, stdname=stdname, units=units)
     call fld_add(flds_x2i, flds_x2i_map, "Faxa_swndf")
     call fld_add(flds_x2l, flds_x2l_map, "Faxa_swndf")
+    call fld_add(flds_x2o, flds_x2o_map, "Foxx_swndf", longname=longname, stdname=stdname, units=units)
 
     ! diffuse visible incident solar radiation
     longname = 'Diffuse visible incident solar radiation'
@@ -650,6 +654,7 @@ contains
     call fld_add(flds_a2x, flds_a2x_map, "Faxa_swvdf", longname=longname, stdname=stdname, units=units)
     call fld_add(flds_x2i, flds_x2i_map, "Faxa_swvdf")
     call fld_add(flds_x2l, flds_x2l_map, "Faxa_swvdf")
+    call fld_add(flds_x2o, flds_x2o_map, "Foxx_swvdf", longname=longname, stdname=stdname, units=units)
 
     ! Net shortwave radiation
     longname = 'Net shortwave radiation'

--- a/src/share/util/shr_flux_mod.F90
+++ b/src/share/util/shr_flux_mod.F90
@@ -24,6 +24,7 @@ module shr_flux_mod
    use shr_sys_mod     ! shared system routines
    use shr_log_mod, only: s_loglev  => shr_log_Level
    use shr_log_mod, only: s_logunit => shr_log_Unit
+   use ESMF
 
    implicit none
 
@@ -68,6 +69,8 @@ module shr_flux_mod
    real(R8) :: loc_latvap = shr_const_latvap
    real(R8) :: loc_latice = shr_const_latice
    real(R8) :: loc_stebol = shr_const_stebol
+   integer :: rc
+   character(len=1024) :: tmpstr
 
 !===============================================================================
 contains
@@ -274,6 +277,9 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,  prec_gust, gust_
 
    al2 = log(zref/ztref)
 
+!   write(tmpstr,'(2i12)') nmax,sum(mask)
+!   call ESMF_LogWrite(trim(subname)//" : n,tcx0 "//trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
+
    DO n=1,nMax
      if (mask(n) /= 0) then
 
@@ -385,6 +391,11 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,  prec_gust, gust_
         sen (n) =          cp * tau * tstar / ustar
         lat (n) =  loc_latvap * tau * qstar / ustar
         lwup(n) = -loc_stebol * ts(n)**4
+
+!        write(tmpstr,'(i6,4g16.7)') n,cp,tau,tstar,ustar
+!        call ESMF_LogWrite(trim(subname)//" : n,tcx1 "//trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
+!        write(tmpstr,'(i6,4g16.7)') n,sen(n),rbot(n),ubot(n),us(n)
+!        call ESMF_LogWrite(trim(subname)//" : n,tcx2 "//trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
 
         !--- water flux ---
         evap(n) = lat(n)/loc_latvap


### PR DESCRIPTION
Initial changes for MOM6 support in CIME

More detailed description:

- Added linker commands in config/cesm/machines/Makefile for FMS library based on USE_FMS environment variable
- NUOPC driver updated to import MOM6 cap if macro ESMFUSE_MOM is defined
- Mediator updates:
  - Support added to convert ESMF Grid to Mesh inside completeFieldInitialization() subroutine
  - Computation of total rain, snow, and prec for ocean in med_phases_prep_ocn()
- Radiation fields added for export from Mediator to ocean
- Grid coordinate diagnostics for center and corner staggers now written to log in shr_nuopc_methods_Grid_Print() subroutine
- Updates to compile MOM6 on Theia
- Theia updated to use ESMF v7.1.0r

Test suite:
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:

Code review: